### PR TITLE
array -> array:array

### DIFF
--- a/src/mongo_pool.erl
+++ b/src/mongo_pool.erl
@@ -17,7 +17,7 @@
 
 -record(state, {
 	supervisor  :: pid(),
-	connections :: array(),
+	connections :: array:array(),
 	monitors    :: orddict:orddict()
 }).
 


### PR DESCRIPTION
So it works on R18 (my dev machine is now R18)

In other news I looked at the heritage of this forked forked fork and note that we've lost some parents and the sooner we get rid the hell of Mongo the better, I'm amazed this even works.
